### PR TITLE
Documentation in InternetAddress is wrong

### DIFF
--- a/mail/src/main/java/javax/mail/internet/InternetAddress.java
+++ b/mail/src/main/java/javax/mail/internet/InternetAddress.java
@@ -104,12 +104,6 @@ public class InternetAddress extends Address implements Cloneable {
      * Parse the given string and create an InternetAddress.
      * See the <code>parse</code> method for details of the parsing.
      * The address is parsed using "strict" parsing.
-     * This constructor does <b>not</b> perform the additional
-     * syntax checks that the
-     * <code>InternetAddress(String address, boolean strict)</code>
-     * constructor does when <code>strict</code> is <code>true</code>.
-     * This constructor is equivalent to
-     * <code>InternetAddress(address, false)</code>.
      *
      * @param address	the address in RFC822 format
      * @exception	AddressException if the parse failed

--- a/mail/src/main/java/javax/mail/internet/InternetAddress.java
+++ b/mail/src/main/java/javax/mail/internet/InternetAddress.java
@@ -140,10 +140,7 @@ public class InternetAddress extends Address implements Cloneable {
 						throws AddressException {
 	this(address);
 	if (strict) {
-	    if (isGroup())
-		getGroup(true);	// throw away the result
-	    else
-		checkAddress(this.address, true, true);
+	    validate();
 	}
     }
 


### PR DESCRIPTION
InternetAddress a[] = parse(address, true); is called, despite the comment saying it calls InternetAddress(address, false). Thats quite confusing without looking at the sources! I spent quite some work time on that.

It's not an actual source code change, but just a documentation correction, I hope thats fine without signing Oracle Contributor Agreement. Feel free to correct it in any way you want.