### PR TITLE
javamail: allow relaxed parsing of content disposition

### DIFF
--- a/doc/release/CHANGES.txt
+++ b/doc/release/CHANGES.txt
@@ -21,6 +21,7 @@ The following bugs have been fixed in the 1.6.1 release.
 
 GH  262	Some IMAP servers send EXPUNGE responses for unknown messages
 GH  283	clean up connections when closing IMAPStore
+GH  287	Allow relaxed Content-Disposition parsing
 
 
 		  CHANGES IN THE 1.6.0 RELEASE

--- a/mail/src/main/java/javax/mail/internet/ContentDisposition.java
+++ b/mail/src/main/java/javax/mail/internet/ContentDisposition.java
@@ -43,6 +43,7 @@ package javax.mail.internet;
 import javax.mail.*;
 import java.util.*;
 import java.io.*;
+import com.sun.mail.util.*;
 
 /**
  * This class represents a MIME ContentDisposition value. It provides
@@ -53,6 +54,9 @@ import java.io.*;
  */
 
 public class ContentDisposition {
+
+    private static final boolean contentDispositionStrict =
+        PropUtil.getBooleanSystemProperty("mail.mime.contentdisposition.strict", true);
 
     private String disposition; // disposition
     private ParameterList list;	// parameter list
@@ -89,10 +93,14 @@ public class ContentDisposition {
 
 	// First "disposition" ..
 	tk = h.next();
-	if (tk.getType() != HeaderTokenizer.Token.ATOM)
-	    throw new ParseException("Expected disposition, got " +
-					tk.getValue());
-	disposition = tk.getValue();
+	if (tk.getType() != HeaderTokenizer.Token.ATOM) {
+            if (contentDispositionStrict) {
+	        throw new ParseException("Expected disposition, got " +
+				    tk.getValue());
+            }
+        } else {
+	    disposition = tk.getValue();
+        }
 
 	// Then parameters ..
 	String rem = h.getRemainder();

--- a/mail/src/main/java/javax/mail/internet/package.html
+++ b/mail/src/main/java/javax/mail/internet/package.html
@@ -290,6 +290,21 @@ The default value of this property is false.
 </TD>
 </TR>
 
+<A NAME="mail.mime.contentdisposition.strict"></A>
+<TR id="mail.mime.contentdisposition.strict">
+<TD>mail.mime.contentdisposition. strict</TD>
+<TD>boolean</TD>
+<TD>
+Normally, when parsing headers related to a MIME attachment
+the content-disposition is parsed as if well formed and an
+<code>ParseException</code> is thrown otherwise.  This System
+property maybe set to <code>false</code> to suppress the
+exception and continue parsing through the malformed
+content disposition.
+The default value of this property is true.
+</TD>
+</TR>
+
 </TABLE>
 
 

--- a/mail/src/test/java/javax/mail/internet/ContentDispositionNoStrict.java
+++ b/mail/src/test/java/javax/mail/internet/ContentDispositionNoStrict.java
@@ -40,25 +40,33 @@
 
 package javax.mail.internet;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite.SuiteClasses;
-
-import com.sun.mail.test.ClassLoaderSuite;
-import com.sun.mail.test.ClassLoaderSuite.TestClass;
+import org.junit.*;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 /**
- * Suite of ParameterList tests that need to be run in a separate class loader.
+ * Test the property that contols ContentDisposition non-strict mode
  */
-@RunWith(ClassLoaderSuite.class)
-@TestClass(ParameterList.class)
-@SuiteClasses( {
-    ParameterListTests.class,
-    WindowsFileNames.class,
-    AppleFileNames.class,
-    NonAsciiFileNames.class,
-    DecodeParameters.class,
-    ParametersNoStrict.class,
-    ContentDispositionNoStrict.class
-})
-public class ParameterListTestSuite {
+public class ContentDispositionNoStrict {
+
+    @BeforeClass
+    public static void before() {
+        System.setProperty("mail.mime.contentdisposition.strict", "false");
+    }
+
+    @Test
+    public void testDecode() throws Exception {
+        try {
+            ContentDisposition cd = new ContentDisposition("\"/non/standard/stuff/here.csv\"");
+            assertNull("Content disposition must parse to null in non-strict mode", cd.getDisposition());
+        } catch (ParseException px) {
+            fail("Exception must not be thrown in non-strict mode");
+        }
+    }
+
+    @AfterClass
+    public static void after() {
+        System.clearProperty("mail.mime.contentdisposition.strict");
+    }
 }
+

--- a/mail/src/test/java/javax/mail/internet/ContentDispositionStrict.java
+++ b/mail/src/test/java/javax/mail/internet/ContentDispositionStrict.java
@@ -40,24 +40,33 @@
 
 package javax.mail.internet;
 
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite.SuiteClasses;
-
-import com.sun.mail.test.ClassLoaderSuite;
-import com.sun.mail.test.ClassLoaderSuite.TestClass;
+import org.junit.*;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 
 /**
- * Suite of ParameterList tests that need to be run in a separate class loader.
+ * Test the property that contols ContentDisposition non-strict mode
  */
-@RunWith(ClassLoaderSuite.class)
-@TestClass(ParameterList.class)
-@SuiteClasses( {
-    ParameterListTests.class,
-    WindowsFileNames.class,
-    AppleFileNames.class,
-    NonAsciiFileNames.class,
-    DecodeParameters.class,
-    ParametersNoStrict.class
-})
-public class ParameterListTestSuite {
+public class ContentDispositionStrict {
+
+    @BeforeClass
+    public static void before() {
+        System.setProperty("mail.mime.contentdisposition.strict", "true");
+    }
+
+    @Test
+    public void testDecode() throws Exception {
+        try {
+            ContentDisposition cd = new ContentDisposition("\"/non/standard/stuff/here.csv\"");
+            fail("ParseException should be thrown on malformed content disposition");
+        } catch (ParseException expected) {
+            // the exception is the expected outcome in this test
+        }
+    }
+
+    @AfterClass
+    public static void after() {
+        System.clearProperty("mail.mime.contentdisposition.strict");
+    }
 }
+

--- a/mail/src/test/java/javax/mail/internet/ContentDispositionTestSuite.java
+++ b/mail/src/test/java/javax/mail/internet/ContentDispositionTestSuite.java
@@ -50,14 +50,10 @@ import com.sun.mail.test.ClassLoaderSuite.TestClass;
  * Suite of ParameterList tests that need to be run in a separate class loader.
  */
 @RunWith(ClassLoaderSuite.class)
-@TestClass(ParameterList.class)
+@TestClass(ContentDisposition.class)
 @SuiteClasses( {
-    ParameterListTests.class,
-    WindowsFileNames.class,
-    AppleFileNames.class,
-    NonAsciiFileNames.class,
-    DecodeParameters.class,
-    ParametersNoStrict.class
+    ContentDispositionNoStrict.class,
+    ContentDispositionStrict.class
 })
-public class ParameterListTestSuite {
+public class ContentDispositionTestSuite {
 }


### PR DESCRIPTION
When processing emails in the wild one can encounter a malformed content disposition value.
This PR would allow a boolean property to be set to relax the parsing and avoid throwing the exception.

This is my first contribution here. The OCA has been signed and submitted. If there are either
process or code things that I'm missing or that would facilitate this and future contributions
please guide me along as you have time.  