### PR TITLE
Add QUIT support on session rejection

### DIFF
--- a/doc/release/CHANGES.txt
+++ b/doc/release/CHANGES.txt
@@ -25,6 +25,7 @@ GH  283	clean up connections when closing IMAPStore
 GH  287	Allow relaxed Content-Disposition parsing
 GH  289	use a different IMAP tag prefix for each connection
 GH  291	define JDK 9 module name for JavaMail
+GH  295	Add QUIT support on session rejection
 
 
 		  CHANGES IN THE 1.6.0 RELEASE

--- a/mail/src/main/java/com/sun/mail/smtp/SMTPTransport.java
+++ b/mail/src/main/java/com/sun/mail/smtp/SMTPTransport.java
@@ -2187,8 +2187,8 @@ public class SMTPTransport extends Transport {
 			}
 		    }
 		} catch (Exception e) {
-		    if (logger.isLoggable(Level.ALL))
-			logger.log(Level.ALL, "QUIT failed", e);
+		    if (logger.isLoggable(Level.FINE))
+			logger.log(Level.FINE, "QUIT failed", e);
 		} finally {
 		    serverSocket.close();
 		    serverSocket = null;
@@ -2240,8 +2240,8 @@ public class SMTPTransport extends Transport {
 			}
 		    }
 		} catch (Exception e) {
-		    if (logger.isLoggable(Level.ALL))
-			logger.log(Level.ALL, "QUIT failed", e);
+		    if (logger.isLoggable(Level.FINE))
+			logger.log(Level.FINE, "QUIT failed", e);
 		} finally {
 		    serverSocket.close();
 		    serverSocket = null;

--- a/mail/src/main/java/com/sun/mail/smtp/SMTPTransport.java
+++ b/mail/src/main/java/com/sun/mail/smtp/SMTPTransport.java
@@ -114,6 +114,7 @@ public class SMTPTransport extends Transport {
     private String defaultAuthenticationMechanisms;	// set in constructor
 
     private boolean quitWait = false;	// true if we should wait
+    private boolean quitOnSessionReject = false;   // true if we should send quit when session initiation is rejected
 
     private String saslRealm = UNKNOWN;
     private String authorizationID = UNKNOWN;
@@ -196,6 +197,11 @@ public class SMTPTransport extends Transport {
 	// response from the QUIT command
 	quitWait = PropUtil.getBooleanSessionProperty(session,
 				"mail." + name + ".quitwait", true);
+
+        // setting mail.smtp.quitonsessionreject to false causes us to directly
+        // close the socket without sending a QUIT command
+        quitOnSessionReject = PropUtil.getBooleanSessionProperty(session,
+                                "mail." + name + ".quitonsessionreject", false);
 
 	// mail.smtp.reportsuccess causes us to throw an exception on success
 	reportSuccess = PropUtil.getBooleanSessionProperty(session,
@@ -2170,19 +2176,26 @@ public class SMTPTransport extends Transport {
 
 	    int r = -1;
 	    if ((r = readServerResponse()) != 220) {
-		serverSocket.close();
-		serverSocket = null;
-		serverOutput = null;
-		serverInput = null;
-		lineInputStream = null;
-		if (logger.isLoggable(Level.FINE))
-		    logger.fine("could not connect to host \"" +
-				    host + "\", port: " + port +
-				    ", response: " + r);
-		throw new MessagingException(
-			"Could not connect to SMTP host: " + host +
-				    ", port: " + port +
-				    ", response: " + r);
+		try {
+		    if (quitOnSessionReject) {
+			sendCommand("QUIT");
+			if (quitWait) {
+			    int resp = readServerResponse();
+			    if (resp != 221 && resp != -1 &&
+				logger.isLoggable(Level.FINE))
+				logger.fine("QUIT failed with " + resp);
+			}
+		    }
+		} catch (Exception e) {
+		    if (logger.isLoggable(Level.ALL))
+			logger.log(Level.ALL, "QUIT failed", e);
+		} finally {
+		    serverSocket.close();
+		    serverSocket = null;
+		    serverOutput = null;
+		    serverInput = null;
+		    lineInputStream = null;
+		}
 	    } else {
 		if (logger.isLoggable(Level.FINE))
 		    logger.fine("connected to host \"" +
@@ -2216,11 +2229,26 @@ public class SMTPTransport extends Transport {
 
 	    int r = -1;
 	    if ((r = readServerResponse()) != 220) {
-		serverSocket.close();
-		serverSocket = null;
-		serverOutput = null;
-		serverInput = null;
-		lineInputStream = null;
+		try {
+		    if (quitOnSessionReject) {
+			sendCommand("QUIT");
+			if (quitWait) {
+			    int resp = readServerResponse();
+			    if (resp != 221 && resp != -1 &&
+				logger.isLoggable(Level.FINE))
+				logger.fine("QUIT failed with " + resp);
+			}
+		    }
+		} catch (Exception e) {
+		    if (logger.isLoggable(Level.ALL))
+			logger.log(Level.ALL, "QUIT failed", e);
+		} finally {
+		    serverSocket.close();
+		    serverSocket = null;
+		    serverOutput = null;
+		    serverInput = null;
+		    lineInputStream = null;
+		}
 		if (logger.isLoggable(Level.FINE))
 		    logger.fine("got bad greeting from host \"" +
 				    host + "\", port: " + port +

--- a/mail/src/main/java/com/sun/mail/smtp/package.html
+++ b/mail/src/main/java/com/sun/mail/smtp/package.html
@@ -518,8 +518,9 @@ for the response to the QUIT command.
 <TD>boolean</TD>
 <TD>
 If set to false (the default), on session initiation rejection the QUIT
-command is not sent sent and the connection is immediately closed.
-If set to true, causes the transport to send the QUIT command prior to close the connection.
+command is not sent and the connection is immediately closed.
+If set to true, causes the transport to send the QUIT command prior to
+closing the connection.
 </TD>
 </TR>
 

--- a/mail/src/main/java/com/sun/mail/smtp/package.html
+++ b/mail/src/main/java/com/sun/mail/smtp/package.html
@@ -514,6 +514,16 @@ for the response to the QUIT command.
 </TR>
 
 <TR>
+<TD><A NAME="mail.smtp.quitonsessionreject">mail.smtp.quitonsessionreject</A></TD>
+<TD>boolean</TD>
+<TD>
+If set to false (the default), on session initiation rejection the QUIT
+command is not sent sent and the connection is immediately closed.
+If set to true, causes the transport to send the QUIT command prior to close the connection.
+</TD>
+</TR>
+
+<TR>
 <TD><A NAME="mail.smtp.reportsuccess">mail.smtp.reportsuccess</A></TD>
 <TD>boolean</TD>
 <TD>


### PR DESCRIPTION
Acutally on session initiation rejection (banner response 554 not 220) SMTPTransport abruptly closes the connection.

RFC5321 (https://tools.ietf.org/html/rfc5321#section-3.1) states that:
> The SMTP protocol allows a server to formally reject a mail session
> while still allowing the initial connection as follows: a 554
> response MAY be given in the initial connection opening message
> instead of the 220.  A server taking this approach MUST still wait
> for the client to send a QUIT (see Section 4.1.1.10) before closing
> the connection and SHOULD respond to any intervening commands with
> "503 bad sequence of commands".

The same RFC doesn't tell how client should react to session rejection so closing the connection is totally valid.

Pratically speaking I've encountered SMTP servers not behaving totally well to such conduct. To accomodate such servers I've added a new property `mail.smtp.quitonsessionreject` to send a QUIT command after session rejection, defaulting to false to keep old known behaviour.