### PR TITLE
Add missing package to MimeMultipartParseTest

### DIFF
--- a/mail/src/test/java/javax/mail/internet/MimeMultipartParseTest.java
+++ b/mail/src/test/java/javax/mail/internet/MimeMultipartParseTest.java
@@ -38,6 +38,8 @@
  * holder.
  */
 
+package javax.mail.internet;
+
 import java.util.*;
 import java.io.*;
 import javax.mail.*;


### PR DESCRIPTION
The missing package in MimeMultipartParseTest caused the test to fail for me.