### PR TITLE
Allow relaxed Content-Disposition to apply to Content-Disposition properties

### DIFF
--- a/doc/release/CHANGES.txt
+++ b/doc/release/CHANGES.txt
@@ -30,6 +30,7 @@ GH  317	use System.lineSeparator() instead of System.getProperty(...)
 GH  321	URLName.getURL() returns incorrect url.
 GH  322	Dots in local part of emails not handled properly
 GH  323	Support loading protocol providers using ServiceLoader
+GH  326	Apply relaxed Content-Disposition parsing to Content-Disposition parameters
 
 
 		  CHANGES IN THE 1.6.1 RELEASE

--- a/mail/src/main/java/javax/mail/internet/ContentDisposition.java
+++ b/mail/src/main/java/javax/mail/internet/ContentDisposition.java
@@ -105,7 +105,14 @@ public class ContentDisposition {
 	// Then parameters ..
 	String rem = h.getRemainder();
 	if (rem != null)
-	    list = new ParameterList(rem);
+            try {
+                list = new ParameterList(rem);
+            } catch (ParseException px) {
+                if (contentDispositionStrict) {
+                    throw px;
+                }
+            }
+        }
     }
 
     /**

--- a/mail/src/test/java/javax/mail/internet/ContentDispositionNoStrict.java
+++ b/mail/src/test/java/javax/mail/internet/ContentDispositionNoStrict.java
@@ -64,6 +64,16 @@ public class ContentDispositionNoStrict {
         }
     }
 
+    @Test
+    public void testDecodeWithParams() throws Exception {
+        try {
+            ContentDisposition cd = new ContentDisposition(" ; size=12345");
+            assertNull("Content disposition must parse to null in non-strict mode", cd.getDisposition());
+        } catch (ParseException px) {
+            fail("Exception must not be thrown in non-strict mode");
+        }
+    }
+
     @AfterClass
     public static void after() {
         System.clearProperty("mail.mime.contentdisposition.strict");


### PR DESCRIPTION
Reference issue #326 to allow the relaxed content-disposition parsing to apply not only to the primary value but to any optional parameters supplied on the Content-Disposition header as well.