### PR TITLE
fix gimap set labels error with some non english characters

### DIFF
--- a/gimap/src/main/java/com/sun/mail/gimap/protocol/GmailProtocol.java
+++ b/gimap/src/main/java/com/sun/mail/gimap/protocol/GmailProtocol.java
@@ -195,8 +195,13 @@ public class GmailProtocol extends IMAPProtocol {
     private Argument createLabelList(String[] labels) {
 	Argument args = new Argument();	
 	Argument itemArgs = new Argument();
-	for (int i = 0, len = labels.length; i < len; i++)
-	    itemArgs.writeAtom(labels[i]);
+	for (int i = 0, len = labels.length; i < len; i++) {
+        try {
+            itemArgs.writeString(labels[i], "UTF-8");
+        } catch (UnsupportedEncodingException uex){
+            itemArgs.writeAtom(labels[i]);
+        }
+    }
 	args.writeArgument(itemArgs);
 	return args;
     }


### PR DESCRIPTION
when you set labels with gmail like `标签` or some non English characters will throw error