### PR TITLE
HTTP proxy auth support

### DIFF
--- a/mail/src/main/java/com/sun/mail/util/SocketFetcher.java
+++ b/mail/src/main/java/com/sun/mail/util/SocketFetcher.java
@@ -52,7 +52,6 @@ import java.util.logging.Level;
 import java.security.cert.*;
 import javax.net.*;
 import javax.net.ssl.*;
-import javax.security.auth.x500.X500Principal;
 
 /**
  * This class is used to get Sockets. Depending on the arguments passed
@@ -275,8 +274,10 @@ public class SocketFetcher {
 		", host " + host + ", port " + port +
 		", connection timeout " + cto + ", timeout " + to +
 		", socket factory " + sf + ", useSSL " + useSSL);
-		
+
 	String proxyHost = props.getProperty(prefix + ".proxy.host", null);
+	final String proxyUser = props.getProperty(prefix + ".proxy.user", null);
+	final String proxyPassword = props.getProperty(prefix + ".proxy.password", null);
 	int proxyPort = 80;
 	String socksHost = null;
 	int socksPort = 1080;
@@ -346,7 +347,7 @@ public class SocketFetcher {
 	try {
 	    logger.finest("connecting...");
 	    if (proxyHost != null)
-		proxyConnect(socket, proxyHost, proxyPort, host, port, cto);
+		proxyConnect(socket, proxyHost, proxyPort, proxyUser, proxyPassword, host, port, cto);
 	    else if (cto >= 0)
 		socket.connect(new InetSocketAddress(host, port), cto);
 	    else
@@ -407,7 +408,7 @@ public class SocketFetcher {
 	if (sfClass == null || sfClass.length() == 0)
 	    return null;
 
-	// dynamically load the class 
+	// dynamically load the class
 
 	ClassLoader cl = getContextClassLoader();
 	Class<?> clsSockFact = null;
@@ -419,7 +420,7 @@ public class SocketFetcher {
 	if (clsSockFact == null)
 	    clsSockFact = Class.forName(sfClass);
 	// get & invoke the getDefault() method
-	Method mthGetDefault = clsSockFact.getMethod("getDefault", 
+	Method mthGetDefault = clsSockFact.getMethod("getDefault",
 						     new Class<?>[]{});
 	SocketFactory sf = (SocketFactory)
 	    mthGetDefault.invoke(new Object(), new Object[]{});
@@ -662,7 +663,7 @@ public class SocketFetcher {
     /**
      * Check the server from the Socket connection against the server name(s)
      * as expressed in the server certificate (RFC 2595 check).
-     * 
+     *
      * @param	server		name of the server expected
      * @param   sslSocket	SSLSocket connected to the server
      * @exception	IOException	if we can't verify identity of server
@@ -693,7 +694,7 @@ public class SocketFetcher {
 
     /**
      * Do any of the names in the cert match the server name?
-     *  
+     *
      * @param	server	name of the server expected
      * @param   cert	X509Certificate to get the subject's name from
      * @return  true if it matches
@@ -714,7 +715,7 @@ public class SocketFetcher {
 	    // invoke HostnameChecker.getInstance(HostnameChecker.TYPE_LDAP)
 	    // HostnameChecker.TYPE_LDAP == 2
 	    // LDAP requires the same regex handling as we need
-	    Method getInstance = hnc.getMethod("getInstance", 
+	    Method getInstance = hnc.getMethod("getInstance",
 					new Class<?>[] { byte.class });
 	    Object hostnameChecker = getInstance.invoke(new Object(),
 					new Object[] { Byte.valueOf((byte)2) });
@@ -819,8 +820,8 @@ public class SocketFetcher {
      * </pre>
      */
     private static void proxyConnect(Socket socket,
-				String proxyHost, int proxyPort,
-				String host, int port, int cto)
+				String proxyHost, int proxyPort, String proxyUser,
+			 		String proxyPassword, String host, int port, int cto)
 				throws IOException {
 	if (logger.isLoggable(Level.FINE))
 	    logger.fine("connecting through proxy " +
@@ -832,8 +833,16 @@ public class SocketFetcher {
 	    socket.connect(new InetSocketAddress(proxyHost, proxyPort));
 	PrintStream os = new PrintStream(socket.getOutputStream(), false,
 					    StandardCharsets.UTF_8.name());
-	os.print("CONNECT " + host + ":" + port + " HTTP/1.1\r\n");
-	os.print("Host: " + host + ":" + port + "\r\n\r\n");
+	final StringBuilder requestBuilder = new StringBuilder();
+	requestBuilder.append("CONNECT ").append(host).append(":").append(port).append(" HTTP/1.1\r\n");
+	requestBuilder.append("Host: ").append(host).append(":").append(port).append("\r\n");
+	if (proxyUser != null && proxyPassword != null) {
+		final String proxyHeaderValue = encodeBase64(proxyUser +':'+proxyPassword);
+		requestBuilder.append("Proxy-Authorization: Basic ").append(proxyHeaderValue).append("\r\n");
+	}
+	requestBuilder.append("Proxy-Connection: keep-alive\r\n\r\n");
+	final String request = requestBuilder.toString();
+	os.print(request);
 	os.flush();
 	BufferedReader r = new BufferedReader(new InputStreamReader(
 			    socket.getInputStream(), StandardCharsets.UTF_8));
@@ -865,7 +874,27 @@ public class SocketFetcher {
 	}
     }
 
-    /**
+	/**
+	 * Encodes the provided String with Base64. Uses the clases from JavaMail instead of the JDK to ensure
+	 * JDK 7 compatibility.
+	 * @param unencodedString the String to encode
+	 * @return the encoded String
+	 */
+	private static String encodeBase64(String unencodedString) throws IOException {
+		final InputStream unencodedIS = new ByteArrayInputStream(unencodedString.getBytes());
+		try(final ByteArrayOutputStream encodedOS = new ByteArrayOutputStream()){
+			final BASE64EncoderStream base64OS = new BASE64EncoderStream(encodedOS, Integer.MAX_VALUE);
+			byte byteBuffer[] = new byte[1024];
+			int byteCount;
+			while ((byteCount = unencodedIS.read(byteBuffer)) > 0) {
+				base64OS.write(byteBuffer, 0, byteCount);
+			}
+			base64OS.flush();
+			return encodedOS.toString(StandardCharsets.UTF_8.name());
+        }
+	}
+
+	/**
      * Parse a string into whitespace separated tokens
      * and return the tokens in an array.
      */

--- a/mail/src/test/java/com/sun/mail/util/SocketFetcherTest.java
+++ b/mail/src/test/java/com/sun/mail/util/SocketFetcherTest.java
@@ -119,6 +119,10 @@ public final class SocketFetcherTest {
 	    properties.setProperty("mail.test.port", "2");
 	    properties.setProperty("mail.test." + type + ".host",
 				    host.replace("PPPP", sport));
+	    properties.setProperty("mail.test." + type + ".user",
+				    "proxy user");
+	    properties.setProperty("mail.test." + type + ".password",
+				    "proxy password");
 	    if (port != null)
 		properties.setProperty("mail.test." + type + ".port",
 				    port.replace("PPPP", sport));


### PR DESCRIPTION
Hi @bshannon,

as discussed here's my pull request for proxy auth support. I did not change logging as it looks grown and I guess it requires some special knowledge.

I changed the output to the `PrintStream` from multiple `os.print` invocations to `os.print` with a `StringBuilder` result as tcpdump on my computer always only printed the first line - just the `CONNECT` line, but not the `Host:` one.

Florian